### PR TITLE
Fixed passing URL to cmd

### DIFF
--- a/PureManApplicationDevelopment/PureManClickOnce.cs
+++ b/PureManApplicationDevelopment/PureManClickOnce.cs
@@ -339,7 +339,7 @@ namespace PureManApplicationDeployment
             {
                 // hack because of this: https://github.com/dotnet/corefx/issues/10361
                 url = url.Replace("&", "^&");
-                return Process.Start(new ProcessStartInfo("cmd", $"/c start {url}")
+                return Process.Start(new ProcessStartInfo("cmd", $"/c start \"\"{url}\"\"")
                     {
                         CreateNoWindow = true,
                         WindowStyle = ProcessWindowStyle.Hidden,


### PR DESCRIPTION
When a passed URL had a space in it (user name, folder name etc...), the "hack" would throw a runtime error from the cmd command, without interrupting the execution of the rest of the code.