### PR TITLE
Add NetCoreApp3.1 Support

### DIFF
--- a/PureManApplicationDevelopment/ExtensionMethods.cs
+++ b/PureManApplicationDevelopment/ExtensionMethods.cs
@@ -1,0 +1,61 @@
+﻿// ***********************************************************************
+// Assembly         : PureManApplicationDeployment
+// Author           : RFBomb
+// Created          : 03-30-2022
+//
+// Last Modified By : RFBomb
+// Last Modified On : 3-30-2022
+// ***********************************************************************
+// <copyright file="PureManClickOnce.cs" company="PureManApplicationDeployment">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+// <summary></summary>
+// ***********************************************************************
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Syroot.Windows.IO;
+using System.Runtime.CompilerServices;
+
+namespace PureManApplicationDeployment
+{
+    internal static class Extensions
+    {
+        /// <inheritdoc cref="CancellationToken.IsCancellationRequested"/>
+        [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+        [DebuggerHidden]
+        public static bool IsCancellationRequested(this CancellationToken? token) => token.HasValue && token.Value.IsCancellationRequested;
+
+
+        /// <inheritdoc cref="CancellationToken.ThrowIfCancellationRequested"/>
+        [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+        [DebuggerHidden]
+        public static void ThrowIfCancellationRequested(this CancellationToken? token)
+        {
+            if (token.HasValue)
+                token.Value.ThrowIfCancellationRequested();
+        }
+
+#if NETCOREAPP3_1_OR_GREATER
+        //This does not exist in NoreCoreApp but it does in Net5
+        public static Task WaitForExitAsync(this Process proc, CancellationToken token)
+        {
+            var tcs = new TaskCompletionSource<object>();
+            proc.Exited += (_, __) =>
+            {
+                proc?.WaitForExit(); //ensure process has exited!
+                tcs.TrySetResult(true);
+            };
+            if (proc?.HasExited ?? true) return Task.CompletedTask;
+            return Task.Run(() => Task.WaitAll(new Task[] { tcs.Task }, token));
+        }
+#endif
+
+    }
+}

--- a/PureManApplicationDevelopment/PureManApplicationDeployment.csproj
+++ b/PureManApplicationDevelopment/PureManApplicationDeployment.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0-windows</TargetFrameworks>
+      <PlatformTargets>x86;x64</PlatformTargets>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PureManApplicationDevelopment/PureManApplicationDeployment.csproj
+++ b/PureManApplicationDevelopment/PureManApplicationDeployment.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0-windows</TargetFrameworks>
-      <PlatformTargets>x86;x64</PlatformTargets>
+    <TargetPlatforms>x86;x64</TargetPlatforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PureManApplicationDevelopment/PureManApplicationDeployment.csproj
+++ b/PureManApplicationDevelopment/PureManApplicationDeployment.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0-windows</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PureManApplicationDevelopment/PureManClickOnce.cs
+++ b/PureManApplicationDevelopment/PureManClickOnce.cs
@@ -138,6 +138,14 @@ namespace PureManApplicationDeployment
         public string DataDir => _DataDir;
 
         /// <summary>
+        /// Gets the Web site or file share from which this application updates itself.
+        /// </summary>
+        /// <returns>
+        /// The publishPath passed into the constructor.
+        /// </returns>
+        public string UpdateLocation => _PublishPath;
+
+        /// <summary>
         /// The last time the application checked for an update. 
         /// <br/>The last time <see cref="RefreshServerVersion(CancellationToken?)"/> was called.
         /// </summary>

--- a/PureManApplicationDevelopment/PureManClickOnce.cs
+++ b/PureManApplicationDevelopment/PureManClickOnce.cs
@@ -305,7 +305,17 @@ namespace PureManApplicationDeployment
                 throw new ClickOnceDeploymentException("Can't start update process");
             }
 
+#if NET5_0_OR_GREATER
             await proc.WaitForExitAsync();
+#elif NETCOREAPP3_1
+            var tcs = new TaskCompletionSource<object>();
+            proc.Exited += (_, __) =>
+            {
+                proc.WaitForExit(); //ensure process has exited!
+                tcs.TrySetResult(true);
+            };
+            if (!proc.HasExited) await tcs.Task;
+#endif
 
             if (!string.IsNullOrEmpty(setupPath))
             {

--- a/PureManApplicationDevelopment/PureManClickOnce.cs
+++ b/PureManApplicationDevelopment/PureManClickOnce.cs
@@ -3,8 +3,8 @@
 // Author           : Skif
 // Created          : 02-04-2021
 //
-// Last Modified By : Skif
-// Last Modified On : 02-04-2021
+// Last Modified By : RFBomb
+// Last Modified On : 03-03-2022
 // ***********************************************************************
 // <copyright file="PureManClickOnce.cs" company="PureManApplicationDeployment">
 //     Copyright (c) . All rights reserved.
@@ -24,45 +24,13 @@ using Syroot.Windows.IO;
 
 namespace PureManApplicationDeployment
 {
+
     /// <summary>
     /// Class PureManClickOnce.
     /// </summary>
     public class PureManClickOnce
     {
-        /// <summary>
-        /// The is network deployment
-        /// </summary>
-        private readonly bool _IsNetworkDeployment;
-        /// <summary>
-        /// The current application name
-        /// </summary>
-        private readonly string _CurrentAppName;
-        /// <summary>
-        /// The current path
-        /// </summary>
-        private readonly string _CurrentPath;
-        /// <summary>
-        /// The publish path
-        /// </summary>
-        private readonly string _PublishPath;
-        /// <summary>
-        /// The data dir
-        /// </summary>
-        private readonly string _DataDir;
-        /// <summary>
-        /// From
-        /// </summary>
-        private InstallFrom _From;
-        /// <summary>
-        /// Gets a value indicating whether this instance is network deployment.
-        /// </summary>
-        /// <value><c>true</c> if this instance is network deployment; otherwise, <c>false</c>.</value>
-        public bool IsNetworkDeployment => _IsNetworkDeployment;
-        /// <summary>
-        /// Gets the data dir.
-        /// </summary>
-        /// <value>The data dir.</value>
-        public string DataDir => _DataDir;
+        #region < Constructor >
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PureManClickOnce"/> class.
@@ -92,6 +60,54 @@ namespace PureManApplicationDeployment
             }
             SetInstallFrom();
         }
+
+        #endregion
+
+        #region < Private Fields  >
+
+        /// <summary>
+        /// The is network deployment
+        /// </summary>
+        private readonly bool _IsNetworkDeployment;
+        /// <summary>
+        /// The current application name
+        /// </summary>
+        private readonly string _CurrentAppName;
+        /// <summary>
+        /// The current path
+        /// </summary>
+        private readonly string _CurrentPath;
+        /// <summary>
+        /// The publish path
+        /// </summary>
+        private readonly string _PublishPath;
+        /// <summary>
+        /// The data dir
+        /// </summary>
+        private readonly string _DataDir;
+        /// <summary>
+        /// From
+        /// </summary>
+        private InstallFrom _From;
+
+        #endregion
+
+        #region < Public Properties >
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is network deployment.
+        /// </summary>
+        /// <value><c>true</c> if this instance is network deployment; otherwise, <c>false</c>.</value>
+        public bool IsNetworkDeployment => _IsNetworkDeployment;
+        /// <summary>
+        /// Gets the data dir.
+        /// </summary>
+        /// <value>The data dir.</value>
+        public string DataDir => _DataDir;
+
+        #endregion
+
+        #region < Private Constructor Methods >
 
         /// <summary>
         /// Searches the application data dir.
@@ -143,6 +159,10 @@ namespace PureManApplicationDeployment
                 _From = InstallFrom.NoNetwork;
             }
         }
+
+        #endregion
+
+        #region < Read Version Information >
 
         /// <summary>
         /// Currents the version.
@@ -244,6 +264,10 @@ namespace PureManApplicationDeployment
 
             return new Version(version);
         }
+
+        #endregion
+
+        #region < Check For & Update >
 
         /// <summary>
         /// Updates the available.
@@ -374,5 +398,8 @@ namespace PureManApplicationDeployment
 
             return false;
         }
+
+#endregion
+
     }
 }


### PR DESCRIPTION
The original objective of this was to update the project to support NetCoreApp3.1. As I was building my wrapper that extends this, seen here: [ClickOnceApplicationDeployment](https://github.com/RFBProducts/ClickOnceApplicationDeployment), I decided to bring this project more in line with the `System.Deployment.dll` as far as naming, descriptions etc go, and bring some of the functionality from the original dll into this project. 

What I then did with those changes was create a unifying dll to allow a single reference for both .netFramework and .Net/.NetCore, so consumers didn't have to work around which version their code targeted, since it provided similar functionality for both targets